### PR TITLE
fix(Tabs): Погрешность при округлении ширины элементов в Chrome

### DIFF
--- a/packages/core/src/styled/Tabs/common/useTabs.ts
+++ b/packages/core/src/styled/Tabs/common/useTabs.ts
@@ -48,7 +48,7 @@ export const useTabs = <T extends TabItem = TabItem>({
         scrollWidth: number,
         clientWidth: number,
     ) => {
-        if (scrollWidth === clientWidth) {
+        if (scrollWidth <= clientWidth) {
             setScrollPosition(TABS_SCROLL_POSITIONS.none);
         } else if (scrollLeft === 0) {
             setScrollPosition(TABS_SCROLL_POSITIONS.start);
@@ -62,7 +62,7 @@ export const useTabs = <T extends TabItem = TabItem>({
     const onScroll: UIEventHandler<HTMLDivElement> = (event) => {
         const { scrollWidth, scrollLeft, clientWidth } = event.currentTarget;
 
-        detectScrollPosition(scrollLeft, scrollWidth, clientWidth);
+        detectScrollPosition(scrollLeft, scrollWidth, Math.ceil(clientWidth));
     };
 
     const initOnSelect = (


### PR DESCRIPTION
Chrome округляет значения ширины непредсказуемо, может выбирать как округление в меньшую, так и в большую сторону без видимых причин. В расчет положения скролла табов добавлена поправка для учета возможных погрешностей округления.