### PR TITLE
feat: добавлен хук **useProps**

### DIFF
--- a/packages/core/src/main/Chips/stories/Chips.story.tsx
+++ b/packages/core/src/main/Chips/stories/Chips.story.tsx
@@ -60,7 +60,6 @@ Required<ChipsPropsWithoutHtml>,
     rightIcon: true,
     hidden: false,
     rotateRightIcon: true,
-    cssVars: {},
 };
 
 export default {

--- a/packages/core/src/main/SidePage/stories/SidePage.story.tsx
+++ b/packages/core/src/main/SidePage/stories/SidePage.story.tsx
@@ -3,7 +3,6 @@ import { BASE_ARG_TYPES } from '@core/storybook/BASE_ARG_TYPES';
 import { Story } from '@storybook/react/types-6-0';
 import { defineCategory, excludeProp } from '@core/storybook/templateParams';
 import { DisplayVariants } from '@core/storybook/DisplayVariants';
-import { ModalProps } from '@core';
 import {
     directionDescription,
     secondWindowDescription,

--- a/packages/core/styles/engine/theme/hooks/index.ts
+++ b/packages/core/styles/engine/theme/hooks/index.ts
@@ -1,3 +1,6 @@
 export { usePropsOverwrites } from './usePropsOverwrites';
 export { useTheme } from './useTheme';
 export * from './useMedia';
+export * from './useProps';
+export * from './useBem';
+export * from './useStylesOverwrites';

--- a/packages/core/styles/engine/theme/hooks/useBem/index.ts
+++ b/packages/core/styles/engine/theme/hooks/useBem/index.ts
@@ -1,0 +1,1 @@
+export * from './useBem';

--- a/packages/core/styles/engine/theme/hooks/useBem/types.ts
+++ b/packages/core/styles/engine/theme/hooks/useBem/types.ts
@@ -1,0 +1,26 @@
+import { Classes, StylesCallback, StylesWithCallback } from '@core';
+import { ClassNameList, NoStrictEntityMods } from '@bem-react/classname';
+
+export interface TypedCnFormatter<Key extends string> {
+    (elemName: Key): string;
+    (elemName: Key, elemMix?: ClassNameList): string;
+    (elemName: Key, elemMods?: NoStrictEntityMods | null, elemMix?: ClassNameList): string;
+}
+
+export type UseBemPropsType<
+    Props extends object,
+    StyleKey extends string,
+> =
+    & Props
+    & { classes?: Classes<StyleKey> }
+
+export type UseBemTypeCast<
+    T extends object,
+    StyleKey extends string,
+    CSSVarNames extends Partial<Record<string, string>> = Record<string, string>
+> =
+    & UseBemPropsType<T, StyleKey>
+    & {
+        styles?: Partial<StylesWithCallback<StyleKey, T>> | StylesCallback<StyleKey, T>;
+        className?: string;
+    }

--- a/packages/core/styles/engine/theme/hooks/useBem/useBem.ts
+++ b/packages/core/styles/engine/theme/hooks/useBem/useBem.ts
@@ -1,0 +1,26 @@
+import { ComponentsProps } from '@core';
+import { cn as bem } from '@bem-react/classname';
+import { TypedCnFormatter, UseBemPropsType, UseBemTypeCast } from './types';
+import clsx from 'clsx';
+
+export const useBem = <Props extends object, StyleKey extends string>(
+    name: keyof ComponentsProps | string,
+    props: UseBemPropsType<Props, StyleKey>,
+) => {
+    const typedProps = props as UseBemTypeCast<Props, StyleKey>
+
+    const {
+        classes,
+        className,
+    } = typedProps;
+
+    const bemCn = bem(`Qx${name}`);
+
+    const cn: TypedCnFormatter<StyleKey> = (key, ...args: any) => (
+        key === 'root'
+            ? clsx(bemCn(...args), classes?.[key], className)
+            : clsx(bemCn(key, ...args), classes?.[key])
+    );
+
+    return { cn, name };
+};

--- a/packages/core/styles/engine/theme/hooks/useProps/index.ts
+++ b/packages/core/styles/engine/theme/hooks/useProps/index.ts
@@ -1,0 +1,1 @@
+export * from './useProps';

--- a/packages/core/styles/engine/theme/hooks/useProps/types.ts
+++ b/packages/core/styles/engine/theme/hooks/useProps/types.ts
@@ -1,0 +1,10 @@
+import { Styles, WithPermissions, Permissions } from '@core';
+
+export type UsePropsType<Props extends object, StyleKey extends string> =
+    & Props
+    & WithPermissions
+    & { styles?: Styles<StyleKey> }
+
+export type UsePropsReturn<Props extends object> =
+    & Omit<Props, 'styles'>
+    & Permissions

--- a/packages/core/styles/engine/theme/hooks/useProps/useProps.ts
+++ b/packages/core/styles/engine/theme/hooks/useProps/useProps.ts
@@ -1,0 +1,55 @@
+import { UsePropsReturn, UsePropsType } from '@core/styles/engine/theme/hooks/useProps/types';
+import { ComponentsProps, extractStyles, Theme, useTheme } from '@core';
+import { useBem } from '@core/styles/engine/theme/hooks/useBem';
+import { UseBemPropsType } from '@core/styles/engine/theme/hooks/useBem/types';
+
+export const usePropsWithoutTheme = <
+    Props extends object,
+    StyleKey extends string,
+    CSSVarNames extends Record<string, string> = Record<string, string>
+>(
+    name: keyof ComponentsProps | string,
+    props: UseBemPropsType<Props, StyleKey>,
+    theme: Theme,
+    cssVarNames?: CSSVarNames,
+) => {
+    const {
+        permissions,
+        styles,
+        ...restProps
+    } = props as UsePropsType<Props, StyleKey>;
+
+    const resolvedProps = {
+        ...(restProps ?? {}),
+        ...(permissions ?? {}),
+    } as UsePropsReturn<Props>
+
+    const { cn } = useBem(name, props);
+
+    const propsStyles = extractStyles(resolvedProps, theme, styles, cssVarNames);
+
+    const styleProps = {
+        cssVars: cssVarNames,
+        styles: propsStyles,
+    }
+
+    return {
+        props: resolvedProps,
+        cn,
+        name,
+        styleProps,
+    }
+};
+
+export const useProps = <
+    Props extends object,
+    StyleKey extends string,
+    CSSVarNames extends Record<string, string> = Record<string, string>
+>(
+    name: keyof ComponentsProps | string,
+    props: UseBemPropsType<Props, StyleKey>,
+    cssVarNames?: CSSVarNames,
+) => {
+    const resolvedTheme = useTheme();
+    return usePropsWithoutTheme(name, props, resolvedTheme, cssVarNames);
+};

--- a/packages/core/styles/engine/theme/hooks/usePropsOverwrites/types.ts
+++ b/packages/core/styles/engine/theme/hooks/usePropsOverwrites/types.ts
@@ -1,46 +1,43 @@
-import { ClassNameList, NoStrictEntityMods } from '@bem-react/classname';
-import { Classes, Permissions, Styles, StylesCallback, StylesWithCallback } from '@core';
-
-export interface TypedCnFormatter<Key extends string> {
-    (elemName: Key): string;
-    (elemName: Key, elemMix?: ClassNameList): string;
-    (elemName: Key, elemMods?: NoStrictEntityMods | null, elemMix?: ClassNameList): string;
-}
+import { Permissions, Styles, WithPermissions } from '@core';
+import {
+    TypedCnFormatter,
+    UseBemPropsType,
+    UseBemTypeCast
+} from '@core/styles/engine/theme/hooks/useBem/types';
 
 export interface StyleProps<
     StyleKey extends string,
     CSSVarNames extends Partial<Record<string, string>> = Record<string, string>
 > {
-    styles: Styles<StyleKey>,
-    cssVars?: CSSVarNames,
+    styles: Styles<StyleKey>;
+    cssVars?: CSSVarNames;
 }
 
 export type UsePropsOverwritesPropsType<
-    T extends object,
+    Props extends object,
     StyleKey extends string,
     CSSVarNames extends Partial<Record<string, string>> = Record<string, string>
-> = T & {
-    classes?: Classes<StyleKey>,
-    cssVars?: Partial<Record<keyof CSSVarNames, unknown>>,
-}
+> =
+    & Props
+    & UseBemPropsType<Props, StyleKey>
+    & { cssVars?: Partial<Record<keyof CSSVarNames, unknown>> }
 
 export type UsePropsOverwritesPropsTypeCast<
-    T extends object,
+    Props extends object,
     StyleKey extends string,
     CSSVarNames extends Partial<Record<string, string>> = Record<string, string>
-> = UsePropsOverwritesPropsType<T, StyleKey, CSSVarNames> & {
-    styles?: Partial<StylesWithCallback<StyleKey, T>> | StylesCallback<StyleKey, T>,
-    className?: string,
-    permissions?: Permissions,
-}
+> =
+    & UsePropsOverwritesPropsType<Props, StyleKey, CSSVarNames>
+    & UseBemTypeCast<Props, StyleKey>
+    & WithPermissions
 
 export interface UsePropsOverwritesReturnType<
-    T,
+    Props,
     StyleKey extends string,
     CSSVars extends Partial<Record<string, string>>
 > {
-    props: Omit<T, keyof StyleProps<StyleKey, CSSVars> | 'ref'> & Permissions,
-    cn: TypedCnFormatter<StyleKey>,
-    name: string,
-    styleProps: StyleProps<StyleKey, CSSVars>,
+    props: Omit<Props, keyof StyleProps<StyleKey, CSSVars> | 'ref'> & Permissions;
+    cn: TypedCnFormatter<StyleKey>;
+    name: string;
+    styleProps: StyleProps<StyleKey, CSSVars>;
 }

--- a/packages/core/styles/engine/theme/hooks/useStylesOverwrites/index.ts
+++ b/packages/core/styles/engine/theme/hooks/useStylesOverwrites/index.ts
@@ -1,0 +1,1 @@
+export * from './useStylesOverwrites';

--- a/packages/core/styles/engine/theme/hooks/useStylesOverwrites/useStylesOverwrites.ts
+++ b/packages/core/styles/engine/theme/hooks/useStylesOverwrites/useStylesOverwrites.ts
@@ -1,0 +1,44 @@
+import { ComponentsProps, extractStyles, omitProps, Theme, useTheme } from '@core';
+import { UseBemTypeCast } from '@core/styles/engine/theme/hooks/useBem/types';
+import { mergeStyles } from '@core/styles/engine/theme/hooks/usePropsOverwrites/helpers';
+
+export const useStylesOverwritesWithoutTheme = <
+    Props extends object,
+    CSSVarNames extends Record<string, string>,
+    StyleKey extends string
+>(
+    props: Props,
+    cssVarNames: CSSVarNames | undefined,
+    overwritesOrName: Props | keyof ComponentsProps,
+    theme: Theme,
+) => {
+    const resolvedProps = props as UseBemTypeCast<Props, StyleKey>;
+    const resolvedOverwrites = (typeof overwritesOrName === 'string'
+        ? theme.defaultProps?.[overwritesOrName]
+        : overwritesOrName) as UseBemTypeCast<Props, StyleKey>;
+    const mergedProps = omitProps<typeof resolvedProps, 'styles'>({
+        ...(resolvedOverwrites ?? {}),
+        ...(resolvedProps ?? {}),
+    }, ['styles']);
+    const overwritesStyles = extractStyles(mergedProps as Props, theme, resolvedOverwrites?.styles, cssVarNames);
+    const propsStyles = extractStyles(mergedProps as Props, theme, resolvedProps?.styles, cssVarNames);
+
+    return mergeStyles(propsStyles, overwritesStyles);
+}
+
+export const useStylesOverwrites = <
+    Props extends object,
+    CSSVarNames extends Record<string, string>,
+    StyleKey extends string
+>(
+    props: Props,
+    cssVarNames: CSSVarNames | undefined,
+    overwritesOrName: Props | keyof ComponentsProps,
+) => {
+    const theme = useTheme();
+    const resolvedOverwrites = (typeof overwritesOrName === 'string'
+        ? theme.defaultProps?.[overwritesOrName]
+        : overwritesOrName) as UseBemTypeCast<Props, StyleKey>;
+
+    return useStylesOverwritesWithoutTheme(props, cssVarNames, resolvedOverwrites, theme);
+};

--- a/packages/core/styles/engine/types.ts
+++ b/packages/core/styles/engine/types.ts
@@ -39,8 +39,6 @@ export interface WithClassesAndStyles<
     styles?:
         | Partial<StylesWithCallback<Keys, Props>>
         | ((theme: Theme, props: Required<Props>, cssVars: Record<CSSVars, string>) => Partial<Styles<Keys>>);
-
-    cssVars?: Partial<Record<CSSVars, string>>;
 }
 
 export type OmitClassesAndStyles<Props extends object> = Omit<Props, keyof WithClassesAndStyles<any>>

--- a/packages/core/utils/object/omitProps/index.ts
+++ b/packages/core/utils/object/omitProps/index.ts
@@ -1,13 +1,14 @@
-export const omitProps = <T extends object = object>(
+export const omitProps = <T extends object, Keys extends keyof T>(
     initialProps: T,
-    excludedProps: Array<keyof T>,
-) => Object.entries(initialProps).reduce<T>((acc, [key, property]) => {
-    if (excludedProps.includes(key as keyof T)) {
-        return acc;
-    }
+    excludedProps: Array<Keys>,
+): Omit<T, Keys> => {
+    const props = { ...initialProps };
 
-    return {
-        ...acc,
-        [key]: property,
-    };
-}, {} as T);
+    excludedProps.forEach((property) => {
+        if (!props[property]) { return; }
+
+        delete props[property];
+    });
+
+    return props;
+};


### PR DESCRIPTION
Логика мерджа стилей, css-переменных и бэм вынесена из `usePropOverwrites` в отдельные хуки.
Добавлен новый хук `useProps` позволяющий использовать логику `usePropsOverwrites` без перезаписывания пропсов компонента в теме. Это полезно для компонентов, которые не хочется добавлять в общий список компонентов `ComponentsProps`, но при этом использовать `bem`.