### PR TITLE
fix(Tabs): Мелкие исправления и доработки

### DIFF
--- a/packages/core/src/main/Tabs/TabsContained/TabsContained.tsx
+++ b/packages/core/src/main/Tabs/TabsContained/TabsContained.tsx
@@ -3,6 +3,7 @@ import React, { ForwardedRef } from 'react';
 import { jsx } from '@emotion/react';
 import { PALETTE_COLORS, usePropsOverwrites, QX_SIZE, mergeRefs, forwardRef } from '@core';
 import clsx from 'clsx';
+import { disableTransitionIf } from '../common/disableTransitionIf';
 import { useStyles } from './styles';
 import { TabItem, TABS_FADE_WIDTH, useTabs } from '../common';
 import { TabsContainedProps } from './types';
@@ -46,12 +47,14 @@ export const TabsContained = forwardRef(<T extends TabItem = TabItem>(
         value,
         internalRef,
         selectedRef,
+        pointerInnerRef,
         selectedLeft,
         selectedWidth,
         scrollPosition,
         initOnSelect,
         initOnKeyPress,
         initOnScroll,
+        isFirstAppearance,
     } = useTabs({
         items,
         value: externalValue,
@@ -109,11 +112,20 @@ export const TabsContained = forwardRef(<T extends TabItem = TabItem>(
             {renderItems()}
             <div
                 className={cn('pointer')}
-                css={[styles.pointer, { width: selectedWidth, left: selectedLeft }]}
+                css={[
+                    styles.pointer,
+                    { width: selectedWidth, left: selectedLeft },
+                    disableTransitionIf(isFirstAppearance),
+                ]}
             >
                 <div
+                    ref={pointerInnerRef}
                     className={cn('pointerInner')}
-                    css={[styles.pointerInner, { left: -selectedLeft }]}
+                    css={[
+                        styles.pointerInner,
+                        { left: -selectedLeft },
+                        disableTransitionIf(isFirstAppearance),
+                    ]}
                 >
                     {renderItems(true)}
                 </div>

--- a/packages/core/src/main/Tabs/TabsContained/styles/index.ts
+++ b/packages/core/src/main/Tabs/TabsContained/styles/index.ts
@@ -31,6 +31,7 @@ export const useStyles = makeStyles((
     pointerInner: {
         display: 'flex',
         position: 'absolute',
+        maxHeight: '100%',
         transition: transitions.create('left'),
     },
 }), { name: 'QxTabsContained' });

--- a/packages/core/src/main/Tabs/TabsDefault/TabsDefault.tsx
+++ b/packages/core/src/main/Tabs/TabsDefault/TabsDefault.tsx
@@ -3,6 +3,7 @@ import React, { ForwardedRef } from 'react';
 import { jsx } from '@emotion/react';
 import { PALETTE_COLORS, usePropsOverwrites, QX_SIZE, mergeRefs, forwardRef } from '@core';
 import clsx from 'clsx';
+import { disableTransitionIf } from '../common/disableTransitionIf';
 import { useStyles } from './styles';
 import { TABS_LINES } from './constants';
 import { TabItem, TABS_FADE_WIDTH, useTabs } from '../common';
@@ -53,6 +54,7 @@ export const TabsDefault = forwardRef(<T extends TabItem = TabItem>(
         initOnSelect,
         initOnKeyPress,
         initOnScroll,
+        isFirstAppearance,
     } = useTabs({
         items,
         value: externalValue,
@@ -103,7 +105,11 @@ export const TabsDefault = forwardRef(<T extends TabItem = TabItem>(
             })}
             <div
                 className={cn('pointer')}
-                css={[styles.pointer, { width: selectedWidth, left: selectedLeft }]}
+                css={[
+                    styles.pointer,
+                    { width: selectedWidth, left: selectedLeft },
+                    disableTransitionIf(isFirstAppearance),
+                ]}
             />
         </TabsContainer>
     );

--- a/packages/core/src/main/Tabs/TabsSegmented/TabsSegmented.tsx
+++ b/packages/core/src/main/Tabs/TabsSegmented/TabsSegmented.tsx
@@ -8,6 +8,7 @@ import { TabItem, TABS_FADE_WIDTH, useTabs } from '../common';
 import { TabsSegmentedProps } from './types';
 import { TabItemSegmented } from './TabItemSegmented';
 import { TABS_SEGMENTED_PADDING } from './constants';
+import { disableTransitionIf } from '../common/disableTransitionIf';
 import { TabsContainer } from '../index';
 
 export const TabsSegmented = forwardRef(<T extends TabItem = TabItem>(
@@ -48,12 +49,14 @@ export const TabsSegmented = forwardRef(<T extends TabItem = TabItem>(
         value,
         internalRef,
         selectedRef,
+        pointerInnerRef,
         selectedLeft,
         selectedWidth,
         scrollPosition,
         initOnSelect,
         initOnKeyPress,
         initOnScroll,
+        isFirstAppearance,
     } = useTabs({
         items,
         value: externalValue,
@@ -120,11 +123,20 @@ export const TabsSegmented = forwardRef(<T extends TabItem = TabItem>(
                 {renderItems()}
                 <div
                     className={cn('pointer')}
-                    css={[styles.pointer, { width: selectedWidth, left: selectedLeft }]}
+                    css={[
+                        styles.pointer,
+                        { width: selectedWidth, left: selectedLeft },
+                        disableTransitionIf(isFirstAppearance),
+                    ]}
                 >
                     <div
                         className={cn('pointerInner')}
-                        css={[styles.pointerInner, { left: -selectedLeft + TABS_SEGMENTED_PADDING }]}
+                        ref={pointerInnerRef}
+                        css={[
+                            styles.pointerInner,
+                            { left: -selectedLeft + TABS_SEGMENTED_PADDING },
+                            disableTransitionIf(isFirstAppearance),
+                        ]}
                     >
                         {renderItems(true)}
                     </div>

--- a/packages/core/src/main/Tabs/TabsSegmented/styles/index.ts
+++ b/packages/core/src/main/Tabs/TabsSegmented/styles/index.ts
@@ -42,6 +42,7 @@ export const useStyles = makeStyles((
     pointerInner: {
         display: 'flex',
         position: 'absolute',
+        maxHeight: '100%',
         transition: transitions.create('left'),
     },
 }), { name: 'QxTabsSegmented' });

--- a/packages/core/src/main/Tabs/__tests__/__snapshots__/Tabs.test.tsx.snap
+++ b/packages/core/src/main/Tabs/__tests__/__snapshots__/Tabs.test.tsx.snap
@@ -28,10 +28,10 @@ exports[`Tabs type:contained style params borderRadius large 1`] = `
       Контакты
     </button>
     <div
-      class="QxTabsContained-pointer css-1hi9yt7-QxTabsContained-pointer"
+      class="QxTabsContained-pointer css-14o1vj3-QxTabsContained-pointer"
     >
       <div
-        class="QxTabsContained-pointerInner css-zmuymi-QxTabsContained-pointerInner"
+        class="QxTabsContained-pointerInner css-bl48yh-QxTabsContained-pointerInner"
       >
         <button
           area-disabled="true"
@@ -91,10 +91,10 @@ exports[`Tabs type:contained style params borderRadius max 1`] = `
       Контакты
     </button>
     <div
-      class="QxTabsContained-pointer css-eewqin-QxTabsContained-pointer"
+      class="QxTabsContained-pointer css-1t0xsd1-QxTabsContained-pointer"
     >
       <div
-        class="QxTabsContained-pointerInner css-zmuymi-QxTabsContained-pointerInner"
+        class="QxTabsContained-pointerInner css-bl48yh-QxTabsContained-pointerInner"
       >
         <button
           area-disabled="true"
@@ -154,10 +154,10 @@ exports[`Tabs type:contained style params borderRadius medium 1`] = `
       Контакты
     </button>
     <div
-      class="QxTabsContained-pointer css-1idkge1-QxTabsContained-pointer"
+      class="QxTabsContained-pointer css-spns5w-QxTabsContained-pointer"
     >
       <div
-        class="QxTabsContained-pointerInner css-zmuymi-QxTabsContained-pointerInner"
+        class="QxTabsContained-pointerInner css-bl48yh-QxTabsContained-pointerInner"
       >
         <button
           area-disabled="true"
@@ -217,10 +217,10 @@ exports[`Tabs type:contained style params borderRadius small 1`] = `
       Контакты
     </button>
     <div
-      class="QxTabsContained-pointer css-1hwwse8-QxTabsContained-pointer"
+      class="QxTabsContained-pointer css-1j6byas-QxTabsContained-pointer"
     >
       <div
-        class="QxTabsContained-pointerInner css-zmuymi-QxTabsContained-pointerInner"
+        class="QxTabsContained-pointerInner css-bl48yh-QxTabsContained-pointerInner"
       >
         <button
           area-disabled="true"
@@ -280,10 +280,10 @@ exports[`Tabs type:contained style params borderRadius xLarge 1`] = `
       Контакты
     </button>
     <div
-      class="QxTabsContained-pointer css-og4lmk-QxTabsContained-pointer"
+      class="QxTabsContained-pointer css-1ot4j81-QxTabsContained-pointer"
     >
       <div
-        class="QxTabsContained-pointerInner css-zmuymi-QxTabsContained-pointerInner"
+        class="QxTabsContained-pointerInner css-bl48yh-QxTabsContained-pointerInner"
       >
         <button
           area-disabled="true"
@@ -343,10 +343,10 @@ exports[`Tabs type:contained style params borderRadius xSmall 1`] = `
       Контакты
     </button>
     <div
-      class="QxTabsContained-pointer css-1nz9dvj-QxTabsContained-pointer"
+      class="QxTabsContained-pointer css-1ogvzwl-QxTabsContained-pointer"
     >
       <div
-        class="QxTabsContained-pointerInner css-zmuymi-QxTabsContained-pointerInner"
+        class="QxTabsContained-pointerInner css-bl48yh-QxTabsContained-pointerInner"
       >
         <button
           area-disabled="true"
@@ -406,10 +406,10 @@ exports[`Tabs type:contained style params color brand 1`] = `
       Контакты
     </button>
     <div
-      class="QxTabsContained-pointer css-1idkge1-QxTabsContained-pointer"
+      class="QxTabsContained-pointer css-spns5w-QxTabsContained-pointer"
     >
       <div
-        class="QxTabsContained-pointerInner css-zmuymi-QxTabsContained-pointerInner"
+        class="QxTabsContained-pointerInner css-bl48yh-QxTabsContained-pointerInner"
       >
         <button
           area-disabled="true"
@@ -469,10 +469,10 @@ exports[`Tabs type:contained style params color danger 1`] = `
       Контакты
     </button>
     <div
-      class="QxTabsContained-pointer css-1ntlfgh-QxTabsContained-pointer"
+      class="QxTabsContained-pointer css-awnm99-QxTabsContained-pointer"
     >
       <div
-        class="QxTabsContained-pointerInner css-zmuymi-QxTabsContained-pointerInner"
+        class="QxTabsContained-pointerInner css-bl48yh-QxTabsContained-pointerInner"
       >
         <button
           area-disabled="true"
@@ -532,10 +532,10 @@ exports[`Tabs type:contained style params color info 1`] = `
       Контакты
     </button>
     <div
-      class="QxTabsContained-pointer css-sdpd2g-QxTabsContained-pointer"
+      class="QxTabsContained-pointer css-2y1yr5-QxTabsContained-pointer"
     >
       <div
-        class="QxTabsContained-pointerInner css-zmuymi-QxTabsContained-pointerInner"
+        class="QxTabsContained-pointerInner css-bl48yh-QxTabsContained-pointerInner"
       >
         <button
           area-disabled="true"
@@ -595,10 +595,10 @@ exports[`Tabs type:contained style params color secondary 1`] = `
       Контакты
     </button>
     <div
-      class="QxTabsContained-pointer css-42blsf-QxTabsContained-pointer"
+      class="QxTabsContained-pointer css-wbxulo-QxTabsContained-pointer"
     >
       <div
-        class="QxTabsContained-pointerInner css-zmuymi-QxTabsContained-pointerInner"
+        class="QxTabsContained-pointerInner css-bl48yh-QxTabsContained-pointerInner"
       >
         <button
           area-disabled="true"
@@ -658,10 +658,10 @@ exports[`Tabs type:contained style params color success 1`] = `
       Контакты
     </button>
     <div
-      class="QxTabsContained-pointer css-1tnf1y6-QxTabsContained-pointer"
+      class="QxTabsContained-pointer css-1w92dvi-QxTabsContained-pointer"
     >
       <div
-        class="QxTabsContained-pointerInner css-zmuymi-QxTabsContained-pointerInner"
+        class="QxTabsContained-pointerInner css-bl48yh-QxTabsContained-pointerInner"
       >
         <button
           area-disabled="true"
@@ -721,10 +721,10 @@ exports[`Tabs type:contained style params color warning 1`] = `
       Контакты
     </button>
     <div
-      class="QxTabsContained-pointer css-a3b0o5-QxTabsContained-pointer"
+      class="QxTabsContained-pointer css-od4109-QxTabsContained-pointer"
     >
       <div
-        class="QxTabsContained-pointerInner css-zmuymi-QxTabsContained-pointerInner"
+        class="QxTabsContained-pointerInner css-bl48yh-QxTabsContained-pointerInner"
       >
         <button
           area-disabled="true"
@@ -784,10 +784,10 @@ exports[`Tabs type:contained style params size large 1`] = `
       Контакты
     </button>
     <div
-      class="QxTabsContained-pointer css-1idkge1-QxTabsContained-pointer"
+      class="QxTabsContained-pointer css-spns5w-QxTabsContained-pointer"
     >
       <div
-        class="QxTabsContained-pointerInner css-zmuymi-QxTabsContained-pointerInner"
+        class="QxTabsContained-pointerInner css-bl48yh-QxTabsContained-pointerInner"
       >
         <button
           area-disabled="true"
@@ -847,10 +847,10 @@ exports[`Tabs type:contained style params size medium 1`] = `
       Контакты
     </button>
     <div
-      class="QxTabsContained-pointer css-1idkge1-QxTabsContained-pointer"
+      class="QxTabsContained-pointer css-spns5w-QxTabsContained-pointer"
     >
       <div
-        class="QxTabsContained-pointerInner css-zmuymi-QxTabsContained-pointerInner"
+        class="QxTabsContained-pointerInner css-bl48yh-QxTabsContained-pointerInner"
       >
         <button
           area-disabled="true"
@@ -910,10 +910,10 @@ exports[`Tabs type:contained style params size small 1`] = `
       Контакты
     </button>
     <div
-      class="QxTabsContained-pointer css-1idkge1-QxTabsContained-pointer"
+      class="QxTabsContained-pointer css-spns5w-QxTabsContained-pointer"
     >
       <div
-        class="QxTabsContained-pointerInner css-zmuymi-QxTabsContained-pointerInner"
+        class="QxTabsContained-pointerInner css-bl48yh-QxTabsContained-pointerInner"
       >
         <button
           area-disabled="true"
@@ -985,10 +985,10 @@ exports[`Tabs type:contained with counter 1`] = `
         </span>
       </button>
       <div
-        class="QxTabsSegmented-pointer css-1cbwojl-QxTabsSegmented-pointer"
+        class="QxTabsSegmented-pointer css-1eb21b-QxTabsSegmented-pointer"
       >
         <div
-          class="QxTabsSegmented-pointerInner css-18rw0ii-QxTabsSegmented-pointerInner"
+          class="QxTabsSegmented-pointerInner css-98qwg5-QxTabsSegmented-pointerInner"
         >
           <button
             area-disabled="true"
@@ -1098,7 +1098,7 @@ exports[`Tabs type:default style params color brand 1`] = `
       </div>
     </button>
     <div
-      class="QxTabsDefault-pointer css-18sj7bv-QxTabsDefault-pointer"
+      class="QxTabsDefault-pointer css-32d5qs-QxTabsDefault-pointer"
     />
   </div>
 </DocumentFragment>
@@ -1171,7 +1171,7 @@ exports[`Tabs type:default style params color danger 1`] = `
       </div>
     </button>
     <div
-      class="QxTabsDefault-pointer css-9nphz5-QxTabsDefault-pointer"
+      class="QxTabsDefault-pointer css-1dmbis-QxTabsDefault-pointer"
     />
   </div>
 </DocumentFragment>
@@ -1244,7 +1244,7 @@ exports[`Tabs type:default style params color info 1`] = `
       </div>
     </button>
     <div
-      class="QxTabsDefault-pointer css-17eu6tz-QxTabsDefault-pointer"
+      class="QxTabsDefault-pointer css-1qtyy9j-QxTabsDefault-pointer"
     />
   </div>
 </DocumentFragment>
@@ -1317,7 +1317,7 @@ exports[`Tabs type:default style params color secondary 1`] = `
       </div>
     </button>
     <div
-      class="QxTabsDefault-pointer css-7q4l1j-QxTabsDefault-pointer"
+      class="QxTabsDefault-pointer css-1necwb4-QxTabsDefault-pointer"
     />
   </div>
 </DocumentFragment>
@@ -1390,7 +1390,7 @@ exports[`Tabs type:default style params color success 1`] = `
       </div>
     </button>
     <div
-      class="QxTabsDefault-pointer css-1ddq0jr-QxTabsDefault-pointer"
+      class="QxTabsDefault-pointer css-qd5j2z-QxTabsDefault-pointer"
     />
   </div>
 </DocumentFragment>
@@ -1463,7 +1463,7 @@ exports[`Tabs type:default style params color warning 1`] = `
       </div>
     </button>
     <div
-      class="QxTabsDefault-pointer css-1hlxoxj-QxTabsDefault-pointer"
+      class="QxTabsDefault-pointer css-g1n7j9-QxTabsDefault-pointer"
     />
   </div>
 </DocumentFragment>
@@ -1536,7 +1536,7 @@ exports[`Tabs type:default style params line down 1`] = `
       </div>
     </button>
     <div
-      class="QxTabsDefault-pointer css-18sj7bv-QxTabsDefault-pointer"
+      class="QxTabsDefault-pointer css-32d5qs-QxTabsDefault-pointer"
     />
   </div>
 </DocumentFragment>
@@ -1609,7 +1609,7 @@ exports[`Tabs type:default style params line up 1`] = `
       </div>
     </button>
     <div
-      class="QxTabsDefault-pointer css-vljbii-QxTabsDefault-pointer"
+      class="QxTabsDefault-pointer css-14kfua0-QxTabsDefault-pointer"
     />
   </div>
 </DocumentFragment>
@@ -1682,7 +1682,7 @@ exports[`Tabs type:default style params size large 1`] = `
       </div>
     </button>
     <div
-      class="QxTabsDefault-pointer css-18sj7bv-QxTabsDefault-pointer"
+      class="QxTabsDefault-pointer css-32d5qs-QxTabsDefault-pointer"
     />
   </div>
 </DocumentFragment>
@@ -1755,7 +1755,7 @@ exports[`Tabs type:default style params size medium 1`] = `
       </div>
     </button>
     <div
-      class="QxTabsDefault-pointer css-18sj7bv-QxTabsDefault-pointer"
+      class="QxTabsDefault-pointer css-32d5qs-QxTabsDefault-pointer"
     />
   </div>
 </DocumentFragment>
@@ -1828,7 +1828,7 @@ exports[`Tabs type:default style params size small 1`] = `
       </div>
     </button>
     <div
-      class="QxTabsDefault-pointer css-18sj7bv-QxTabsDefault-pointer"
+      class="QxTabsDefault-pointer css-32d5qs-QxTabsDefault-pointer"
     />
   </div>
 </DocumentFragment>
@@ -1874,10 +1874,10 @@ exports[`Tabs type:default with counter 1`] = `
         </span>
       </button>
       <div
-        class="QxTabsSegmented-pointer css-1cbwojl-QxTabsSegmented-pointer"
+        class="QxTabsSegmented-pointer css-1eb21b-QxTabsSegmented-pointer"
       >
         <div
-          class="QxTabsSegmented-pointerInner css-18rw0ii-QxTabsSegmented-pointerInner"
+          class="QxTabsSegmented-pointerInner css-98qwg5-QxTabsSegmented-pointerInner"
         >
           <button
             area-disabled="true"
@@ -1951,10 +1951,10 @@ exports[`Tabs type:segmented style params borderRadius large 1`] = `
         Контакты
       </button>
       <div
-        class="QxTabsSegmented-pointer css-1fww4q7-QxTabsSegmented-pointer"
+        class="QxTabsSegmented-pointer css-droeqp-QxTabsSegmented-pointer"
       >
         <div
-          class="QxTabsSegmented-pointerInner css-18rw0ii-QxTabsSegmented-pointerInner"
+          class="QxTabsSegmented-pointerInner css-98qwg5-QxTabsSegmented-pointerInner"
         >
           <button
             area-disabled="true"
@@ -2018,10 +2018,10 @@ exports[`Tabs type:segmented style params borderRadius max 1`] = `
         Контакты
       </button>
       <div
-        class="QxTabsSegmented-pointer css-vxlzhl-QxTabsSegmented-pointer"
+        class="QxTabsSegmented-pointer css-1v3sjyx-QxTabsSegmented-pointer"
       >
         <div
-          class="QxTabsSegmented-pointerInner css-18rw0ii-QxTabsSegmented-pointerInner"
+          class="QxTabsSegmented-pointerInner css-98qwg5-QxTabsSegmented-pointerInner"
         >
           <button
             area-disabled="true"
@@ -2085,10 +2085,10 @@ exports[`Tabs type:segmented style params borderRadius medium 1`] = `
         Контакты
       </button>
       <div
-        class="QxTabsSegmented-pointer css-1cbwojl-QxTabsSegmented-pointer"
+        class="QxTabsSegmented-pointer css-1eb21b-QxTabsSegmented-pointer"
       >
         <div
-          class="QxTabsSegmented-pointerInner css-18rw0ii-QxTabsSegmented-pointerInner"
+          class="QxTabsSegmented-pointerInner css-98qwg5-QxTabsSegmented-pointerInner"
         >
           <button
             area-disabled="true"
@@ -2152,10 +2152,10 @@ exports[`Tabs type:segmented style params borderRadius small 1`] = `
         Контакты
       </button>
       <div
-        class="QxTabsSegmented-pointer css-7jna84-QxTabsSegmented-pointer"
+        class="QxTabsSegmented-pointer css-658zuh-QxTabsSegmented-pointer"
       >
         <div
-          class="QxTabsSegmented-pointerInner css-18rw0ii-QxTabsSegmented-pointerInner"
+          class="QxTabsSegmented-pointerInner css-98qwg5-QxTabsSegmented-pointerInner"
         >
           <button
             area-disabled="true"
@@ -2219,10 +2219,10 @@ exports[`Tabs type:segmented style params borderRadius xLarge 1`] = `
         Контакты
       </button>
       <div
-        class="QxTabsSegmented-pointer css-dtiae1-QxTabsSegmented-pointer"
+        class="QxTabsSegmented-pointer css-1livdin-QxTabsSegmented-pointer"
       >
         <div
-          class="QxTabsSegmented-pointerInner css-18rw0ii-QxTabsSegmented-pointerInner"
+          class="QxTabsSegmented-pointerInner css-98qwg5-QxTabsSegmented-pointerInner"
         >
           <button
             area-disabled="true"
@@ -2286,10 +2286,10 @@ exports[`Tabs type:segmented style params borderRadius xSmall 1`] = `
         Контакты
       </button>
       <div
-        class="QxTabsSegmented-pointer css-on18kx-QxTabsSegmented-pointer"
+        class="QxTabsSegmented-pointer css-9im1dn-QxTabsSegmented-pointer"
       >
         <div
-          class="QxTabsSegmented-pointerInner css-18rw0ii-QxTabsSegmented-pointerInner"
+          class="QxTabsSegmented-pointerInner css-98qwg5-QxTabsSegmented-pointerInner"
         >
           <button
             area-disabled="true"
@@ -2353,10 +2353,10 @@ exports[`Tabs type:segmented style params color brand 1`] = `
         Контакты
       </button>
       <div
-        class="QxTabsSegmented-pointer css-1cbwojl-QxTabsSegmented-pointer"
+        class="QxTabsSegmented-pointer css-1eb21b-QxTabsSegmented-pointer"
       >
         <div
-          class="QxTabsSegmented-pointerInner css-18rw0ii-QxTabsSegmented-pointerInner"
+          class="QxTabsSegmented-pointerInner css-98qwg5-QxTabsSegmented-pointerInner"
         >
           <button
             area-disabled="true"
@@ -2420,10 +2420,10 @@ exports[`Tabs type:segmented style params color danger 1`] = `
         Контакты
       </button>
       <div
-        class="QxTabsSegmented-pointer css-1cbwojl-QxTabsSegmented-pointer"
+        class="QxTabsSegmented-pointer css-1eb21b-QxTabsSegmented-pointer"
       >
         <div
-          class="QxTabsSegmented-pointerInner css-18rw0ii-QxTabsSegmented-pointerInner"
+          class="QxTabsSegmented-pointerInner css-98qwg5-QxTabsSegmented-pointerInner"
         >
           <button
             area-disabled="true"
@@ -2487,10 +2487,10 @@ exports[`Tabs type:segmented style params color info 1`] = `
         Контакты
       </button>
       <div
-        class="QxTabsSegmented-pointer css-1cbwojl-QxTabsSegmented-pointer"
+        class="QxTabsSegmented-pointer css-1eb21b-QxTabsSegmented-pointer"
       >
         <div
-          class="QxTabsSegmented-pointerInner css-18rw0ii-QxTabsSegmented-pointerInner"
+          class="QxTabsSegmented-pointerInner css-98qwg5-QxTabsSegmented-pointerInner"
         >
           <button
             area-disabled="true"
@@ -2554,10 +2554,10 @@ exports[`Tabs type:segmented style params color secondary 1`] = `
         Контакты
       </button>
       <div
-        class="QxTabsSegmented-pointer css-1cbwojl-QxTabsSegmented-pointer"
+        class="QxTabsSegmented-pointer css-1eb21b-QxTabsSegmented-pointer"
       >
         <div
-          class="QxTabsSegmented-pointerInner css-18rw0ii-QxTabsSegmented-pointerInner"
+          class="QxTabsSegmented-pointerInner css-98qwg5-QxTabsSegmented-pointerInner"
         >
           <button
             area-disabled="true"
@@ -2621,10 +2621,10 @@ exports[`Tabs type:segmented style params color success 1`] = `
         Контакты
       </button>
       <div
-        class="QxTabsSegmented-pointer css-1cbwojl-QxTabsSegmented-pointer"
+        class="QxTabsSegmented-pointer css-1eb21b-QxTabsSegmented-pointer"
       >
         <div
-          class="QxTabsSegmented-pointerInner css-18rw0ii-QxTabsSegmented-pointerInner"
+          class="QxTabsSegmented-pointerInner css-98qwg5-QxTabsSegmented-pointerInner"
         >
           <button
             area-disabled="true"
@@ -2688,10 +2688,10 @@ exports[`Tabs type:segmented style params color warning 1`] = `
         Контакты
       </button>
       <div
-        class="QxTabsSegmented-pointer css-1cbwojl-QxTabsSegmented-pointer"
+        class="QxTabsSegmented-pointer css-1eb21b-QxTabsSegmented-pointer"
       >
         <div
-          class="QxTabsSegmented-pointerInner css-18rw0ii-QxTabsSegmented-pointerInner"
+          class="QxTabsSegmented-pointerInner css-98qwg5-QxTabsSegmented-pointerInner"
         >
           <button
             area-disabled="true"
@@ -2755,10 +2755,10 @@ exports[`Tabs type:segmented style params size large 1`] = `
         Контакты
       </button>
       <div
-        class="QxTabsSegmented-pointer css-1cbwojl-QxTabsSegmented-pointer"
+        class="QxTabsSegmented-pointer css-1eb21b-QxTabsSegmented-pointer"
       >
         <div
-          class="QxTabsSegmented-pointerInner css-18rw0ii-QxTabsSegmented-pointerInner"
+          class="QxTabsSegmented-pointerInner css-98qwg5-QxTabsSegmented-pointerInner"
         >
           <button
             area-disabled="true"
@@ -2822,10 +2822,10 @@ exports[`Tabs type:segmented style params size medium 1`] = `
         Контакты
       </button>
       <div
-        class="QxTabsSegmented-pointer css-1cbwojl-QxTabsSegmented-pointer"
+        class="QxTabsSegmented-pointer css-1eb21b-QxTabsSegmented-pointer"
       >
         <div
-          class="QxTabsSegmented-pointerInner css-18rw0ii-QxTabsSegmented-pointerInner"
+          class="QxTabsSegmented-pointerInner css-98qwg5-QxTabsSegmented-pointerInner"
         >
           <button
             area-disabled="true"
@@ -2889,10 +2889,10 @@ exports[`Tabs type:segmented style params size small 1`] = `
         Контакты
       </button>
       <div
-        class="QxTabsSegmented-pointer css-1cbwojl-QxTabsSegmented-pointer"
+        class="QxTabsSegmented-pointer css-1eb21b-QxTabsSegmented-pointer"
       >
         <div
-          class="QxTabsSegmented-pointerInner css-18rw0ii-QxTabsSegmented-pointerInner"
+          class="QxTabsSegmented-pointerInner css-98qwg5-QxTabsSegmented-pointerInner"
         >
           <button
             area-disabled="true"
@@ -2965,10 +2965,10 @@ exports[`Tabs type:segmented with counter 1`] = `
         </span>
       </button>
       <div
-        class="QxTabsSegmented-pointer css-1cbwojl-QxTabsSegmented-pointer"
+        class="QxTabsSegmented-pointer css-1eb21b-QxTabsSegmented-pointer"
       >
         <div
-          class="QxTabsSegmented-pointerInner css-18rw0ii-QxTabsSegmented-pointerInner"
+          class="QxTabsSegmented-pointerInner css-98qwg5-QxTabsSegmented-pointerInner"
         >
           <button
             area-disabled="true"
@@ -3108,10 +3108,10 @@ exports[`Tabs type:segmented with icons 1`] = `
         </svg>
       </button>
       <div
-        class="QxTabsSegmented-pointer css-1cbwojl-QxTabsSegmented-pointer"
+        class="QxTabsSegmented-pointer css-1eb21b-QxTabsSegmented-pointer"
       >
         <div
-          class="QxTabsSegmented-pointerInner css-18rw0ii-QxTabsSegmented-pointerInner"
+          class="QxTabsSegmented-pointerInner css-98qwg5-QxTabsSegmented-pointerInner"
         >
           <button
             area-disabled="true"

--- a/packages/core/src/main/Tabs/common/disableTransitionIf.ts
+++ b/packages/core/src/main/Tabs/common/disableTransitionIf.ts
@@ -1,0 +1,3 @@
+export const disableTransitionIf = (flag = false) => (
+    flag && { transition: 'none' }
+);

--- a/packages/core/src/main/Tabs/stories/Tabs.story.tsx
+++ b/packages/core/src/main/Tabs/stories/Tabs.story.tsx
@@ -25,11 +25,11 @@ import counterDescription from './descriptions/Counter.md';
 import customComponentDescription from './descriptions/CustomComponent.md';
 
 const items = [
-    { label: 'Главная', value: 'home' },
-    { label: 'Бизнес', value: 'business' },
-    { label: 'Страхование', value: 'insurance' },
-    { label: 'Транспорт', value: 'transport' },
-    { label: 'Медицина', value: 'medicine' },
+    { label: 'Главная страница', value: 'home' },
+    { label: 'Бизнес операции', value: 'business' },
+    { label: 'Страхование жизни', value: 'insurance' },
+    { label: 'Транспорт до дома', value: 'transport' },
+    { label: 'Медицина и здоровье', value: 'medicine' },
     { label: 'Контакты', value: 'contacts' },
 ];
 
@@ -85,16 +85,23 @@ export const Sandbox: Story<TabsProps> = ({
     type,
     items: itemsProp,
     ...props
-}) => (
-    /* eslint-disable-line @typescript-eslint/ban-ts-comment */
-    <Tabs
-        type={type}
-        line={type === TABS_TYPES.default ? line : undefined}
-        icons={type === TABS_TYPES.segmented ? icons : undefined}
-        items={type === TABS_TYPES.segmented && icons ? iconItems : itemsProp}
-        {...props}
-    />
-);
+}) => {
+    const [tab, setTab] = useState('medicine');
+
+    return (
+        <Tabs
+            type="contained"
+            line={type === TABS_TYPES.default ? line : undefined}
+            icons={type === TABS_TYPES.segmented ? icons : undefined}
+            items={type === TABS_TYPES.segmented && icons ? iconItems : itemsProp}
+            value={tab}
+            onSetValue={({ value }) => {
+                setTab(value);
+            }}
+            {...props}
+        />
+    );
+};
 
 Sandbox.args = { ...defaultArgs, size: QX_SIZE.large };
 


### PR DESCRIPTION
Исправлено:
1. Анимация при первом рендере;
2. Неправильный расчет позиции маркера при первом рендере;
3. Неправильный расчет ширины `pointerInner` при наличии пробела в элементе.