### PR TITLE
tech: Исправлена сборка storybook

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -46,6 +46,9 @@ jobs:
             **/node_modules
             ./node_modules
           key: ${{ runner.os }}-nm-${{ hashFiles('**/yarn.lock') }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - run: yarn install --production=false
       - run: yarn run storybook:build
       - uses: JamesIves/github-pages-deploy-action@v4.3.4


### PR DESCRIPTION
Проблема со сборкой сторибука возникла из-за того, что в Node 18 удалили функцию, на которую опираются Webpack и Babel Loader при сборке:
https://github.com/webpack/webpack/issues/14532