### PR TITLE
fix: Типы `StackDirection` и `StackOrder` добавлены в экспорт

### DIFF
--- a/packages/core/src/system/Stack/styles/constants.ts
+++ b/packages/core/src/system/Stack/styles/constants.ts
@@ -14,10 +14,3 @@ export const STACK_ORDER = valuesAsKeysFromArray([
 ]);
 
 export type StackOrder = Values<typeof STACK_ORDER>
-
-export const CHILD_TYPE = valuesAsKeysFromArray([
-    'item',
-    'divider',
-]);
-
-export type ChildType = Values<typeof CHILD_TYPE>

--- a/packages/core/src/system/Stack/styles/types.ts
+++ b/packages/core/src/system/Stack/styles/types.ts
@@ -53,3 +53,5 @@ export interface StackStyleParams {
      * Значения аналогичны css-свойству `align-items` для flex-контейнеров */
     alignItems?: AlignItems;
 }
+
+export type { StackDirection, StackOrder } from './constants';


### PR DESCRIPTION
Удалены неиспользуемые константы и типы